### PR TITLE
Add multiremote authentication

### DIFF
--- a/app.json
+++ b/app.json
@@ -9,10 +9,8 @@
       "description": "Please Paste your rclone.conf file in URL.Use https://gist.github.com \r\n |See Readme in github https://github.com/developeranaz/HEROKU-RCLONE-SERVE-INDEX |➊.Generate rclone.conf file from any terminal or cmd or termux          |➋.You can use Multiple cloud drive accounts in single rclone.conf file          |➌.We need any text/code hosting website, Use gist-github github account needed.           |➍.Open rclone.config file using any text editors and copy all text inside rclone.conf and paste it in gist.            |➎.Choose any file name and save it.          |➏.Then Click RAW button and copy the url.          |➐.Don't share this url to anyone. |➑.Paste your url below." ,
       "value": "https://gist.githu../raw/rclone.conf"
     },
-     "CLOUDNAME": {
-      "description": "Please enter your Cloudname/Remote that you assigned in rclone.conf file.See Readme https://github.com/developeranaz/HEROKU-RCLONE-SERVE-INDEX",
-      "value": ""
-    }
+    "USER": {"description": "Please enter your Username for authentication","value": "admin"},
+    "PASSWORD" : {"description": "Please enter your Password for authentication","value": ""}
 
 
   },

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,4 +5,4 @@ mkdir /.config
 mkdir /.config/rclone/
 wget "$CONFIG_IN_URL" -O /.rclone.conf
 rclone listremotes
-rclone serve http $CLOUDNAME: --addr :$PORT --vfs-read-chunk-size 128M
+rclone rcd --rc-serve --rc-addr=:$PORT --rc-user=$USER --rc-pass=$PASSWORD


### PR DESCRIPTION
Used "rclone rcd" instead of "rclone serve" as rcd support multiremotes. and added authentication.
although "rclone rcd" does not support --vfs-read-chunk-size flag so i don't know what will be the effect on performance.

sorry for not clear language or for any error, this is my first ever pull request.